### PR TITLE
Hide or show Category graph query based on presence of categories

### DIFF
--- a/app/views/codebooks/show.html.erb
+++ b/app/views/codebooks/show.html.erb
@@ -10,12 +10,12 @@
 <% end %>
 
 <h2>Derived categories:</h2>
-  
+
 <% if @categories_histogram %>
   <% if @enqueued_at %>
     <p>Category derivation was started at <%= @enqueued_at %>. Please allow up to 2 minutes for the process to complete. You can reload the page to monitor progress.</p>
   <% end %>
-  
+
   <% if @total_codes.to_i > 0 %>
     <ul class="word-cloud">
       <% @categories_histogram.keys.sort{|a,b| @categories_histogram[a] <=> @categories_histogram[b]}.reverse.each do |category| %>
@@ -25,23 +25,25 @@
       <% end %>
     </ul>
   <% end %>
-  
+
   <% unless @enqueued_at %>
     <%= button_to "Derive Categories", codebook_enqueue_categories_path(@context, params: { enqueued: true }, method: :put ) %>
   <% end %>
-  
-  <h2>tmi-graph query:</h2>
-  <p class="code">
-    <%= Codebook.category_query(@context_key)[:explainer] %><br />
-    <a href="#query" id="copy-to-clipboard" onclick="copyToClipboard('copy-to-clipboard')"><%= Codebook.category_query(@context_key)[:query] %></a>
-  </p>
+
+  <% if @categories_histogram.keys.any? %>
+    <h2>tmi-graph query:</h2>
+    <p class="code">
+      <%= Codebook.category_query(@context_key)[:explainer] %><br />
+      <a href="#query" id="copy-to-clipboard" onclick="copyToClipboard('copy-to-clipboard')"><%= Codebook.category_query(@context_key)[:query] %></a>
+    </p>
+  <% end %>
 
 <% else %>
 
   <p>By design, identities are not categorized.</p>
 
 <% end %>
-  
+
 <div class="two-column">
   <div class="column">
     <h3>Alphabetically</h3>


### PR DESCRIPTION
Applies to a "Codebook" page. The previous behavior was to show the category <> code graph query even when no categories had been derived. This led to a query with no results, which may cause confusion. The new behavior is to hide the graph query unless there are any categories. 